### PR TITLE
Don't display body when status is REQUESTED_RANGE_NOT_SATISFIABLE

### DIFF
--- a/htail.py
+++ b/htail.py
@@ -100,6 +100,8 @@ class HTTPFile(object):
             if encoding != 'identity':
                 body = decode_dict[encoding](body)
             self._offset += len(body)
+            if status == httplib.REQUESTED_RANGE_NOT_SATISFIABLE:
+                return ""
             return body
         if status in TEMPFAIL_STATUS_SET:
             raise HTTPFileTempFail(status)


### PR DESCRIPTION
The body data may be an error message which is not part of the file being tailed, and therefore not useful to see.

On the webserver I'm connecting to the body data returned for status code 416 is:
```
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>416 Requested Range Not Satisfiable</title>
<h1>Requested Range Not Satisfiable</h1>
<p>The server cannot provide the requested range.</p>
```